### PR TITLE
Fix missing version field in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Surfingkeys",
+    "version": "1.17.9",
     "short_name": "Rich shortcuts in vim spirit for productivity with keyboard.",
     "description": "Rich shortcuts to click links/switch tabs/scroll, capture pages, use your browser like vim for productivity.",
     "icons": {


### PR DESCRIPTION
## Summary
- Added missing version field to src/manifest.json
- Used version 1.17.9 from package.json to ensure consistency

## Test plan
- [x] Build the extension with `npm run build:dev`
- [x] Load the unpacked extension from dist/development/chrome/
- [x] Verify extension loads without content.js errors
- [ ] Test basic extension functionality works as expected